### PR TITLE
Fix not init when loading twice via ajax 

### DIFF
--- a/src/TinyMce.php
+++ b/src/TinyMce.php
@@ -74,7 +74,7 @@ class TinyMce extends InputWidget
 
         $options = Json::encode($this->clientOptions);
 
-        $js[] = "tinymce.init($options);";
+        $js[] = "tinymce.remove('#$id');tinymce.init($options);";
         if ($this->triggerSaveOnBeforeValidateForm) {
             $js[] = "$('#{$id}').parents('form').on('beforeValidate', function() { tinymce.triggerSave(); });";
         }


### PR DESCRIPTION
When content  is loaded via ajax twice or more times, TinyMCE was not initialized. This fix it by removing possible existing instances with the same id.