### PR TITLE
TinyMce 6 incompatible with this library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "prefer-stable": true,
     "require": {
         "yiisoft/yii2": "^2.0",
-        "tinymce/tinymce": ">=4"
+        "tinymce/tinymce": "~5.10.3",
     },
     "require-dev": {
         "phpunit/phpunit": "4.*"


### PR DESCRIPTION
TinyMce 6 has deprecated the contextmenu plugin and initialization of library fails if this version has been installed. Until major changes are made to this library, tinyMce version is frozen to `~5.10.3`